### PR TITLE
Fix: Route Middleware Error

### DIFF
--- a/be/app/Http/Middleware/AdminRoleMiddleware.php
+++ b/be/app/Http/Middleware/AdminRoleMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminRoleMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->user() && $request->user()->role === 'admin') {
+            return $next($request);
+        }
+
+        return response()->json(['message' => 'Unauthorized'], 403);
+    }
+}

--- a/be/bootstrap/app.php
+++ b/be/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\AdminRoleMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/be/routes/api.php
+++ b/be/routes/api.php
@@ -13,12 +13,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::put('/users/password', [AuthController::class, 'updatePassword']);
 
     // Admin Only Routes
-    Route::middleware(function ($request, $next) {
-        if ($request->user()->role !== 'admin') {
-            return response()->json(['message' => 'Unauthorized'], 403);
-        }
-        return $next($request);
-    })->group(function () {
+    Route::middleware('admin')->group(function () {
         Route::get('/users', [UserController::class, 'index']);
         Route::post('/users', [UserController::class, 'store']);
         Route::get('/users/{id}', [UserController::class, 'show']);


### PR DESCRIPTION
Resolved the 'Object of class Closure could not be converted to string' error by moving the inline admin check to a dedicated middleware.